### PR TITLE
Add ed to CMakelist to solve dependency problems in isolated builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(catkin REQUIRED COMPONENTS
   pcl_conversions
   base_local_planner
   code_profiler
+  ed
 )
 
 ###################################


### PR DESCRIPTION
Add ed to CMakelist to solve dependency problems in isolated builds

I ran into problems using catkin build